### PR TITLE
fix AssertionError due to non-unicode prompt on python 2.7.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,106 @@
-*.eggs
-*.egg-info
-*.py[co]
+### Python template
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+### JetBrains template
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio
+
+*.iml
+
+## Directory-based project format:
+.idea/
+# if you remove the above rule, at least ignore the following:
+
+# User-specific stuff:
+# .idea/workspace.xml
+# .idea/tasks.xml
+# .idea/dictionaries
+
+# Sensitive or high-churn files:
+# .idea/dataSources.ids
+# .idea/dataSources.xml
+# .idea/sqlDataSources.xml
+# .idea/dynamic.xml
+# .idea/uiDesigner.xml
+
+# Gradle:
+# .idea/gradle.xml
+# .idea/libraries
+
+# Mongo Explorer plugin:
+# .idea/mongoSettings.xml
+
+## File-based project format:
+*.ipr
+*.iws
+
+## Plugin-specific files:
+
+# IntelliJ
+/out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties

--- a/click_repl/__init__.py
+++ b/click_repl/__init__.py
@@ -1,6 +1,6 @@
 from prompt_toolkit.completion import Completer, Completion
 from prompt_toolkit.history import InMemoryHistory
-from prompt_toolkit.shortcuts import get_input
+from prompt_toolkit.shortcuts import prompt
 import click
 import click._bashcomplete
 import click.parser
@@ -66,7 +66,7 @@ def register_repl(group, name='repl'):
             history = InMemoryHistory()
             completer = ClickCompleter(group)
             def get_command():
-                return get_input('> ', completer=completer, history=history)
+                return prompt('> ', completer=completer, history=history)
         else:
             get_command = sys.stdin.readline
 

--- a/click_repl/__init__.py
+++ b/click_repl/__init__.py
@@ -8,6 +8,7 @@ import os
 import shlex
 import sys
 
+
 class ClickCompleter(Completer):
     def __init__(self, cli):
         self.cli = cli
@@ -53,11 +54,11 @@ def register_repl(group, name='repl'):
     @group.command(name=name)
     @click.pass_context
     def cli(old_ctx):
-        '''
+        """
         Start an interactive shell. All subcommands are available in it.
 
         You can also pipe to this command to execute subcommands.
-        '''
+        """
 
         # parent should be available, but we're not going to bother if not
         group_ctx = old_ctx.parent or old_ctx
@@ -65,6 +66,7 @@ def register_repl(group, name='repl'):
         if isatty:
             history = InMemoryHistory()
             completer = ClickCompleter(group)
+
             def get_command():
                 return prompt(u'> ', completer=completer, history=history)
         else:

--- a/click_repl/__init__.py
+++ b/click_repl/__init__.py
@@ -66,7 +66,7 @@ def register_repl(group, name='repl'):
             history = InMemoryHistory()
             completer = ClickCompleter(group)
             def get_command():
-                return prompt('> ', completer=completer, history=history)
+                return prompt(u'> ', completer=completer, history=history)
         else:
             get_command = sys.stdin.readline
 


### PR DESCRIPTION
- added .gitignore support for intellij based projects (generated with the intellij ignore plugin)
- a bit more PEP8 compliance (minor styling)
- using prompt instead of get_input (deprecated)
- fixed the message prompt to be a unicode (would crash on Python 2.7.x with an assertion error)