### PR TITLE
internal click-repl commands (exit / general help for repl usage)

### DIFF
--- a/click_repl/__init__.py
+++ b/click_repl/__init__.py
@@ -1,5 +1,4 @@
 from collections import defaultdict
-
 from prompt_toolkit.completion import Completer, Completion
 from prompt_toolkit.history import InMemoryHistory
 from prompt_toolkit.shortcuts import prompt
@@ -12,23 +11,23 @@ import sys
 import six
 from .exceptions import InternalCommandException, ExitReplException
 
-__internal_commands__ = dict()
+_internal_commands = dict()
 
 
 def _register_internal_command(names, target, description=None):
     assert hasattr(target, '__call__'), 'internal command must be a callable'
-    global __internal_commands__
+    global _internal_commands
     if isinstance(names, six.string_types):
         names = [names]
     elif not isinstance(names, (list, tuple)):
         raise ValueError('"names" must be a string or a list / tuple')
     for name in names:
-        __internal_commands__[name] = (target, description)
+        _internal_commands[name] = (target, description)
 
 
 def _get_registered_target(name, default=None):
-    global __internal_commands__
-    target_info = __internal_commands__.get(name)
+    global _internal_commands
+    target_info = _internal_commands.get(name)
     if target_info:
         return target_info[0]
     return default
@@ -39,7 +38,7 @@ def _exit_internal():
 
 
 def _help_internal():
-    global __internal_commands__
+    global _internal_commands
     formatter = click.HelpFormatter()
     formatter.write_heading('Internal repl help')
     formatter.indent()
@@ -48,7 +47,7 @@ def _help_internal():
     with formatter.section('Internal Commands'):
         formatter.write_text('prefix internal commands with ":"')
         info_table = defaultdict(list)
-        for mnemonic, target_info in __internal_commands__.iteritems():
+        for mnemonic, target_info in _internal_commands.iteritems():
             info_table[target_info[1]].append(mnemonic)
         formatter.write_dl([(', '.join((':{0}'.format(mnemonic) for mnemonic in sorted(mnemonics))), description)
                             for description, mnemonics in info_table.iteritems()])

--- a/click_repl/__init__.py
+++ b/click_repl/__init__.py
@@ -42,6 +42,7 @@ def _help_internal():
     global __internal_commands__
     formatter = click.HelpFormatter()
     formatter.write_heading('Internal repl help')
+    formatter.indent()
     with formatter.section('External Commands'):
         formatter.write_text('prefix external commands with "!"')
     with formatter.section('Internal Commands'):

--- a/click_repl/__init__.py
+++ b/click_repl/__init__.py
@@ -16,7 +16,6 @@ _internal_commands = dict()
 
 def _register_internal_command(names, target, description=None):
     assert hasattr(target, '__call__'), 'internal command must be a callable'
-    global _internal_commands
     if isinstance(names, six.string_types):
         names = [names]
     elif not isinstance(names, (list, tuple)):

--- a/click_repl/__init__.py
+++ b/click_repl/__init__.py
@@ -25,7 +25,6 @@ def _register_internal_command(names, target, description=None):
 
 
 def _get_registered_target(name, default=None):
-    global _internal_commands
     target_info = _internal_commands.get(name)
     if target_info:
         return target_info[0]
@@ -37,7 +36,6 @@ def _exit_internal():
 
 
 def _help_internal():
-    global _internal_commands
     formatter = click.HelpFormatter()
     formatter.write_heading('Internal repl help')
     formatter.indent()

--- a/click_repl/__init__.py
+++ b/click_repl/__init__.py
@@ -142,4 +142,6 @@ def handle_internal_commands(command):
     if command.startswith(':'):
         target = __internal_commands__.get(command[1:])
         if target:
-            target()
+            result = target()
+            if isinstance(result, six.string_types):
+                click.echo(result)

--- a/click_repl/exceptions.py
+++ b/click_repl/exceptions.py
@@ -1,0 +1,6 @@
+class InternalCommandException(Exception):
+    pass
+
+
+class ExitReplException(InternalCommandException):
+    pass

--- a/setup.py
+++ b/setup.py
@@ -14,5 +14,6 @@ setup(
     install_requires=[
         'click',
         'prompt_toolkit',
+        'six',
     ],
 )


### PR DESCRIPTION
add six as an explicit dependency for Py2 / 3 compatibility (already part of prompt_toolkit)