### PR TITLE
add six as an explicit dependency for Py2 / 3 compatibility (already …

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,5 +14,6 @@ setup(
     install_requires=[
         'click',
         'prompt_toolkit',
+        'six',
     ],
 )


### PR DESCRIPTION
…part of prompt_toolkit)