### PR TITLE
Fix tab completion of nested commands (fixes #13)

### DIFF
--- a/click_repl/__init__.py
+++ b/click_repl/__init__.py
@@ -71,10 +71,6 @@ class ClickCompleter(Completer):
         self.cli = cli
 
     def get_completions(self, document, complete_event):
-        # If ends in space, no completions are wished
-        if document.text_before_cursor.rstrip() != document.text_before_cursor:
-            return
-
         # Code analogous to click._bashcomplete.do_complete
 
         try:
@@ -83,7 +79,17 @@ class ClickCompleter(Completer):
             # Invalid command, perhaps caused by missing closing quotation.
             return
 
-        incomplete = args.pop() if args else ''
+        cursor_within_command = \
+            document.text_before_cursor.rstrip() == document.text_before_cursor
+
+        if args and cursor_within_command:
+            # We've entered some text and no space, give completions for the
+            # current word.
+            incomplete = args.pop()
+        else:
+            # We've not entered anything, either at all or for the current
+            # command, so give all relevant completions for this context.
+            incomplete = ''
 
         ctx = click._bashcomplete.resolve_ctx(self.cli, '', args)
         if ctx is None:


### PR DESCRIPTION
This commit fixes the issue with tab completion of nested commands described in #13.

To give an example of what the original issue this fixes is, consider the simple Click CLI using click-repl in https://gist.github.com/BobWhitelock/184e0669c4d76f42f85b674bf9236b69.

Previously with this CLI, while in the REPL, if you enter the following:
```
> first_level_command <tab>
```
no completions would be given, and you would have to start entering part of the next level of commands to get some completions shown.

With this commit, completions are now shown in the above situation without needing to start entering anything.

Thanks!


