### PR TITLE
Document passing `prompt_kwargs`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,6 +44,39 @@ PyPI: `<https://pypi.python.org/pypi/click-repl>`_
 
 .. _click: http://click.pocoo.org/
 
+Advanced Usage
+==============
+
+For more flexibility over how your REPL works you can use the ``repl`` function
+directly instead of ``register_repl``. For example, in your app:
+
+.. code:: python
+
+    import click
+    from click_repl import repl
+    from prompt_toolkit.history import FileHistory
+
+    @click.group()
+    def cli():
+        pass
+
+    @cli.command()
+    def myrepl():
+        prompt_kwargs = {
+            'history': FileHistory('/etc/myrepl/myrepl-history'),
+        }
+        repl(click.get_current_context(), prompt_kwargs=prompt_kwargs)
+
+And then your custom ``myrepl`` command will be available on your CLI, which
+will start a REPL which has its history stored in
+``/etc/myrepl/myrepl-history`` and persist between sessions.
+
+Any arguments that can be passed to the ``python-prompt-toolkit`` Prompt_ class
+can be passed in the ``prompt_kwargs`` argument and will be used when
+instantiating your ``Prompt``.
+
+.. _Prompt: http://python-prompt-toolkit.readthedocs.io/en/stable/pages/reference.html?prompt_toolkit.shortcuts.Prompt#prompt_toolkit.shortcuts.Prompt
+
 License
 =======
 

--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,9 @@ click-repl
 .. image:: https://travis-ci.org/click-contrib/click-repl.svg?branch=master
     :target: https://travis-ci.org/click-contrib/click-repl
 
-In your click_ app::
+In your click_ app:
+
+.. code:: python
 
     import click
     from click_repl import register_repl


### PR DESCRIPTION
This section documents how you can have more flexibility over your `click-repl` prompt, using the existing functionality of `click-repl`.

This resolves #18 as it documents how the requested feature can already be implemented.
