### PR TITLE
don't die on unmatched quotes

### DIFF
--- a/click_repl/__init__.py
+++ b/click_repl/__init__.py
@@ -187,7 +187,11 @@ def repl(
             except ExitReplException:
                 break
 
-        args = shlex.split(command)
+        try:
+            args = shlex.split(command)
+        except ValueError as e:
+            click.echo("{}: {}".format(type(e).__name__, e))
+            continue
 
         try:
             with group.make_context(None, args, parent=group_ctx) as ctx:


### PR DESCRIPTION
fixes #27. outputs an error message to the user and continues the loop.