### PR TITLE
Fix completer typo

### DIFF
--- a/click_repl/__init__.py
+++ b/click_repl/__init__.py
@@ -128,7 +128,7 @@ def bootstrap_prompt(prompt_kwargs, group):
 
     defaults = {
         'history': InMemoryHistory(),
-        'complete': ClickCompleter(group),
+        'completer': ClickCompleter(group),
         'message': u'> ',
     }
 


### PR DESCRIPTION
Hit this when running `master` branch, seems like a quick typo-fix