### PR TITLE
Fix history, fix completer typo, fix auto completion of chained sub commands

### DIFF
--- a/click_repl/__init__.py
+++ b/click_repl/__init__.py
@@ -113,6 +113,20 @@ class ClickCompleter(Completer):
                     display_meta=getattr(command, 'short_help')
                 ))
 
+        while ctx.parent is not None:
+            ctx = ctx.parent
+            if (isinstance(ctx.command, click.MultiCommand) and
+                    ctx.command.chain):
+                remaining_commands = sorted(
+                    set(ctx.command.list_commands(ctx)) -
+                    set(ctx.protected_args))
+                for name in remaining_commands:
+                    command = ctx.command.get_command(ctx, name)
+                    choices.append(Completion(
+                                    name, -len(incomplete),
+                                    display_meta=getattr(command, 'short_help')
+                    ))
+
         for item in choices:
             if item.text.startswith(incomplete):
                 yield item
@@ -128,7 +142,7 @@ def bootstrap_prompt(prompt_kwargs, group):
 
     defaults = {
         'history': InMemoryHistory(),
-        'complete': ClickCompleter(group),
+        'completer': ClickCompleter(group),
         'message': u'> ',
     }
 
@@ -170,8 +184,11 @@ def repl(
     available_commands.pop(repl_command_name, None)
 
     if isatty:
+        prompt_kwargs = prompt_kwargs or {}
+        prompt_kwargs = bootstrap_prompt(prompt_kwargs, group)
+
         def get_command():
-            return prompt(**bootstrap_prompt(prompt_kwargs, group))
+            return prompt(**prompt_kwargs)
     else:
         get_command = sys.stdin.readline
 


### PR DESCRIPTION
Changes:
1. History is not displayed in the latest top of the tree - fixed it
2. Completer typo in the top of the tree - fixed in this commit
3. Porting the changes from Top of the tree click repo for auto-completion of chained sub-commands.