### PR TITLE
Allow ExitReplException to exit the repl

### DIFF
--- a/click_repl/__init__.py
+++ b/click_repl/__init__.py
@@ -227,12 +227,17 @@ def repl(
             e.show()
         except SystemExit:
             pass
+        except ExitReplException:
+            break
 
 
 def register_repl(group, name='repl'):
     """Register :func:`repl()` as sub-command *name* of *group*."""
     group.command(name=name)(click.pass_context(repl))
 
+def exit():
+    """Exit the repl"""
+    _exit_internal()
 
 def dispatch_repl_commands(command):
     """Execute system commands entered in the repl.

--- a/click_repl/__init__.py
+++ b/click_repl/__init__.py
@@ -235,9 +235,11 @@ def register_repl(group, name='repl'):
     """Register :func:`repl()` as sub-command *name* of *group*."""
     group.command(name=name)(click.pass_context(repl))
 
+
 def exit():
     """Exit the repl"""
     _exit_internal()
+
 
 def dispatch_repl_commands(command):
     """Execute system commands entered in the repl.


### PR DESCRIPTION
This fixes #24 by adding a click_repl.exit() command and triggering
an exit when ExitReplException is hit.