### PR TITLE
add cli call to README examples

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,6 +21,7 @@ In your click_ app:
         click.echo("Hello world!")
 
     register_repl(cli)
+    cli()
 
 In the shell::
 
@@ -68,6 +69,8 @@ directly instead of ``register_repl``. For example, in your app:
             'history': FileHistory('/etc/myrepl/myrepl-history'),
         }
         repl(click.get_current_context(), prompt_kwargs=prompt_kwargs)
+        
+    cli()
 
 And then your custom ``myrepl`` command will be available on your CLI, which
 will start a REPL which has its history stored in


### PR DESCRIPTION
I took the example code as "how you run a click-repl app", and was confused when the examples didn't work at all.  I figured it out for the 'advanced usage' example, but when I read the initial example of how to use `register_repl` I assumed that that replaced the `cli()` call.

Of course, it doesn't.  The fact that `register_repl` only _registers the repl_ command is implied by the name, but for such a small example snippet, where everything else needed to function is included, not including the `cli()` line implied to me that it wasn't necessary.  

This update just makes the `cli()` call explicit in both examples, and hopefully nobody else will suffer from my confusion.

Related issue: #44