### PR TITLE
Handle click.exceptions.Exit, introduced in Click 7.0

### DIFF
--- a/click_repl/__init__.py
+++ b/click_repl/__init__.py
@@ -11,6 +11,12 @@ import sys
 import six
 from .exceptions import InternalCommandException, ExitReplException  # noqa
 
+# Handle click.exceptions.Exit introduced in Click 7.0
+try:
+    from click.exceptions import Exit as ClickExit
+except ImportError:
+    class ClickExit(RuntimeError):
+        pass
 
 PY2 = sys.version_info[0] == 2
 
@@ -243,6 +249,8 @@ def repl(  # noqa: C901
                 ctx.exit()
         except click.ClickException as e:
             e.show()
+        except ClickExit:
+            pass
         except SystemExit:
             pass
         except ExitReplException:


### PR DESCRIPTION
First we attempt import of `click.exceptions.Exit`, but if it doesn't exist we polyfill with a local exception class `ClickExit` (that will never be thrown, of course).

Test approach:

- Manually tested using the example code in click-contrib/click-repl#50.
- Tested against python 2.7.15 and 3.7.0
- Tested against Click 6.7 and 7.0.

Fixes click-contrib/click-repl#47
Fixes click-contrib/click-repl#50