### PR TITLE
Update tests to expect hyphens

### DIFF
--- a/tests/test_argument.py
+++ b/tests/test_argument.py
@@ -14,6 +14,6 @@ def test_completion():
         pass
 
     c = ClickCompleter(root_command)
-    completions = list(c.get_completions(Document(u"arg_cmd ")))
+    completions = list(c.get_completions(Document(u"arg-cmd ")))
 
     assert set(x.text for x in completions) == set([u"foo", u"bar"])

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -21,8 +21,8 @@ def test_completion():
         pass
 
     c = ClickCompleter(root_command)
-    completions = list(c.get_completions(Document(u"first_level_command ")))
+    completions = list(c.get_completions(Document(u"first-level-command ")))
 
     assert set(x.text for x in completions) == set(
-        [u"second_level_command_one", u"second_level_command_two"]
+        [u"second-level-command-one", u"second-level-command-two"]
     )

--- a/tests/test_command_collection.py
+++ b/tests/test_command_collection.py
@@ -24,4 +24,4 @@ def test_completion():
     c = ClickCompleter(click.CommandCollection(sources=[foo_group, foobar_group]))
     completions = list(c.get_completions(Document(u"foo")))
 
-    assert set(x.text for x in completions) == set([u"foo_cmd", u"foobar_cmd"])
+    assert set(x.text for x in completions) == set([u"foo-cmd", u"foobar-cmd"])


### PR DESCRIPTION
This fixes tests with click 7.0, which now converts underscores to hyphens in command names. If you have any suggestions for how to have different expectations in 6.0 vs 7.0, let me know.

You can see the commit that changed this behavior here: pallets/click@5d1df0e042b2f8b0dee8f6dd9ce74edce331a950