### PR TITLE
Run tests in tox

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,5 @@
 [flake8]
-ignore = E203, E266, E501, W503, E402, E731
-max-line-length = 80
+ignore = E203, E266, W503, E402, E731
+max-line-length = 90
 max-complexity = 18
 select = B,C,E,F,W,T4,B9

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,12 @@ python:
     - "3.4"
     - "3.5"
     - "3.6"
-    - "3.7-dev"
+    - "3.7"
 
 matrix:
   include:
-    - python: "3.6"
+    - python: "3.7"
       script: tox -e linters
 
-install: pip install tox
+install: pip install tox pytest
 script: sh scripts/runtox.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ matrix:
   include:
     - python: "3.6"
       script: tox -e linters
+      name: linters
 
 install: pip install tox pytest
 script: sh scripts/runtox.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,11 @@ python:
     - "3.4"
     - "3.5"
     - "3.6"
-    - "3.7"
+    - "3.7-dev"
 
 matrix:
   include:
-    - python: "3.7"
+    - python: "3.6"
       script: tox -e linters
 
 install: pip install tox pytest

--- a/click_repl/__init__.py
+++ b/click_repl/__init__.py
@@ -11,12 +11,15 @@ import sys
 import six
 from .exceptions import InternalCommandException, ExitReplException  # noqa
 
+
 # Handle click.exceptions.Exit introduced in Click 7.0
 try:
     from click.exceptions import Exit as ClickExit
 except ImportError:
+
     class ClickExit(RuntimeError):
         pass
+
 
 PY2 = sys.version_info[0] == 2
 

--- a/tests/test_command_collection.py
+++ b/tests/test_command_collection.py
@@ -1,4 +1,3 @@
-
 import click
 from click_repl import ClickCompleter
 from prompt_toolkit.document import Document

--- a/tox.ini
+++ b/tox.ini
@@ -5,12 +5,13 @@ envlist =
 
 [testenv]
 deps=
-    style: flake8
-    test: pytest
+    linters: flake8
+    linters: black
+    py{2.7,py,3.4,3.5,3.6,3.7}: pytest
 commands=
-    style: flake8 []
-    style: black --check .
-    test: py.test []
+    py{2.7,py,3.4,3.5,3.6,3.7}: pytest []
+    linters: flake8 []
+    linters: black --check .
 
 basepython=
     py2.7: python2.7


### PR DESCRIPTION
I was surprised that my fix for click 7.0 passed the travis build when the tests were broken, but it seems to be because the tests weren't actually run in Travis. If I've performed the `tox` changes correctly, this PR will fail in Travis, but after rebasing on my test fix should pass.

- Add `pytest` as a command for each of the python environments
- Fixes a couple formatting discrepancies from `black`.
- Updates line length to be <= 90 characters, and stops ignoring that rule.
- Adds name to differentiate linter build from the Python version test builds

Let me know if you have any suggestions.