### PR TITLE
Use tox-travis instead of custom runtox script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,5 +12,5 @@ matrix:
     - python: "3.6"
       script: tox -e linters
 
-install: pip install tox
-script: sh scripts/runtox.sh
+install: pip install tox-travis
+script: tox

--- a/scripts/runtox.sh
+++ b/scripts/runtox.sh
@@ -1,8 +1,0 @@
-#!/bin/sh
-if [ -z "$1" ]; then
-    searchstring="$(echo py$TRAVIS_PYTHON_VERSION | sed -e 's/pypypy/pypy/g' -e 's/-dev//g')"
-else
-    searchstring="$1"
-fi
-
-exec tox -e $(tox -l | grep $searchstring | tr '\n' ',')

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{2.7,py,3.4,3.5,3.6,3.7}
+    py{27,py,34,35,36,37}
     linters
 
 [testenv]
@@ -12,11 +12,8 @@ commands=
     style: black --check .
     test: py.test []
 
-basepython=
-    py2.7: python2.7
-    py3.4: python3.4
-    py3.5: python3.5
-    py3.6: python3.6
-    py3.7: python3.7
-    pypy: pypy
-    linters: python3
+[travis]
+; This section is used by tox-travis
+; https://pypi.python.org/pypi/tox-travis
+python=
+    3.6: py36,linters


### PR DESCRIPTION
This is a more experimental change. There's a library called [tox-travis](https://github.com/tox-dev/tox-travis) that seems to do the same thing as the `runtox.sh` script. I wanted to submit a PR to see if it does the right thing, but keep it separate from my other test PR.