### PR TITLE
Pass top-level args to subcommand invocation

### DIFF
--- a/click_repl/__init__.py
+++ b/click_repl/__init__.py
@@ -244,7 +244,10 @@ def repl(  # noqa: C901
             continue
 
         try:
-            with group.make_context(None, args, parent=group_ctx) as ctx:
+            # default_map passes the top-level params to the new group to
+            # support top-level required params that would reject the
+            # invocation if missing.
+            with group.make_context(None, args, parent=group_ctx, default_map=old_ctx.params) as ctx:
                 group.invoke(ctx)
                 ctx.exit()
         except click.ClickException as e:


### PR DESCRIPTION
Passes the original parsed argument values as defaults to invoke the new context. Open to suggestions for a better fix, but this addresses the major issue.

Fixes #58