### PR TITLE
support for click 8 completion changes

### DIFF
--- a/click_repl/__init__.py
+++ b/click_repl/__init__.py
@@ -3,13 +3,20 @@ from prompt_toolkit.completion import Completer, Completion
 from prompt_toolkit.history import InMemoryHistory
 from prompt_toolkit.shortcuts import prompt
 import click
-import click.shell_completion
 import click.parser
 import os
 import shlex
 import sys
 import six
 from .exceptions import InternalCommandException, ExitReplException  # noqa
+
+# Handle backwards compatibility between Click 7.0 and 8.0
+try: 
+    import click.shell_completion
+    HAS_C8 = True
+except ImportError:
+    import click._bashcomplete
+    HAS_C8 = False
 
 # Handle click.exceptions.Exit introduced in Click 7.0
 try:
@@ -107,8 +114,12 @@ class ClickCompleter(Completer):
             # We've not entered anything, either at all or for the current
             # command, so give all relevant completions for this context.
             incomplete = ""
-
-        ctx = click.shell_completion._resolve_context(self.cli, {}, "", args)
+        # Resolve context based on click version
+        if HAS_C8:
+            ctx = click.shell_completion._resolve_context(self.cli, {}, "", args)
+        else: 
+            ctx = click._bashcomplete.resolve_ctx(self.cli, "", args)
+            
         if ctx is None:
             return
 

--- a/click_repl/__init__.py
+++ b/click_repl/__init__.py
@@ -3,7 +3,7 @@ from prompt_toolkit.completion import Completer, Completion
 from prompt_toolkit.history import InMemoryHistory
 from prompt_toolkit.shortcuts import prompt
 import click
-import click._bashcomplete
+import click.shell_completion
 import click.parser
 import os
 import shlex
@@ -108,7 +108,7 @@ class ClickCompleter(Completer):
             # command, so give all relevant completions for this context.
             incomplete = ""
 
-        ctx = click._bashcomplete.resolve_ctx(self.cli, "", args)
+        ctx = click.shell_completion._resolve_context(self.cli, {}, "", args)
         if ctx is None:
             return
 


### PR DESCRIPTION
simple migration from `_bashcomplete` to `shell_completion`. Fixes #72.