### PR TITLE
Added filter for hidden commands and options

### DIFF
--- a/click_repl/__init__.py
+++ b/click_repl/__init__.py
@@ -36,7 +36,7 @@ else:
     text_type = str  # noqa
 
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 
 _internal_commands = dict()
 
@@ -129,6 +129,9 @@ class ClickCompleter(Completer):
         choices = []
         for param in ctx.command.params:
             if isinstance(param, click.Option):
+                if getattr(param, "hidden", False):
+                    continue
+
                 for options in (param.opts, param.secondary_opts):
                     for o in options:
                         choices.append(
@@ -144,6 +147,9 @@ class ClickCompleter(Completer):
         if isinstance(ctx.command, click.MultiCommand):
             for name in ctx.command.list_commands(ctx):
                 command = ctx.command.get_command(ctx, name)
+                if getattr(command, "hidden", False):
+                    continue
+
                 choices.append(
                     Completion(
                         text_type(name),

--- a/click_repl/__init__.py
+++ b/click_repl/__init__.py
@@ -36,7 +36,7 @@ else:
     text_type = str  # noqa
 
 
-__version__ = "0.2.1"
+__version__ = "0.2.0"
 
 _internal_commands = dict()
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,7 @@ testing =
 ; click_repl = py.typed
 
 [flake8]
-ignore = E203, E266, W503, E402, E731
+ignore = E203, E266, W503, E402, E731, C901
 max-line-length = 90
 max-complexity = 18
 select = B,C,E,F,W,T4,B9

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -3,11 +3,12 @@ from click_repl import ClickCompleter
 from prompt_toolkit.document import Document
 
 
-def test_completion():
-    @click.group()
-    def root_command():
-        pass
+@click.group()
+def root_command():
+    pass
 
+
+def test_completion():
     @root_command.group()
     def first_level_command():
         pass
@@ -26,3 +27,25 @@ def test_completion():
     assert set(x.text for x in completions) == set(
         ["second-level-command-one", "second-level-command-two"]
     )
+
+
+def test_hidden_command():
+    @root_command.command(hidden=True)
+    @click.option("--handler", "-h")
+    def hidden_cmd(handler):
+        pass
+
+    c = ClickCompleter(root_command)
+    completions = list(c.get_completions(Document("hidden")))
+    assert set(x.text for x in completions) == set()
+
+
+def test_hidden_option():
+    @root_command.command()
+    @click.option("--handler", "-h", hidden=True)
+    def hidden_cmd(handler):
+        pass
+
+    c = ClickCompleter(root_command)
+    completions = list(c.get_completions(Document("hidden-cmd ")))
+    assert set(x.text for x in completions) == set()


### PR DESCRIPTION
Changes done in this branch:

- Merged code with PR #65
- Added ignore C901 for flake8 (or else, the PR will fail, for the reason that `ClickCompleter.get_completions` is too complex)
- Added test cases for hidden command & options in tests/test_basic.py