### PR TITLE
Merged PR #62: Pass top-level args to subcommand invocation

### DIFF
--- a/click_repl/__init__.py
+++ b/click_repl/__init__.py
@@ -265,7 +265,12 @@ def repl(  # noqa: C901
             continue
 
         try:
-            with group.make_context(None, args, parent=group_ctx) as ctx:
+            # default_map passes the top-level params to the new group to
+            # support top-level required params that would reject the
+            # invocation if missing.
+            with group.make_context(
+                None, args, parent=group_ctx, default_map=old_ctx.params
+            ) as ctx:
                 group.invoke(ctx)
                 ctx.exit()
         except click.ClickException as e:

--- a/tests/test_command_collection.py
+++ b/tests/test_command_collection.py
@@ -1,9 +1,9 @@
 import click
-from click_repl import ClickCompleter
+from click_repl import ClickCompleter, repl
 from prompt_toolkit.document import Document
 
 
-def test_completion():
+def test_command_collection():
     @click.group()
     def foo_group():
         pass
@@ -24,3 +24,26 @@ def test_completion():
     completions = list(c.get_completions(Document("foo")))
 
     assert set(x.text for x in completions) == set(["foo-cmd", "foobar-cmd"])
+
+
+def test_subcommand_invocation():
+    @click.group(invoke_without_command=True)
+    @click.option("--user", required=True)
+    @click.pass_context
+    def cli(ctx, user):
+        if ctx.invoked_subcommand is None:
+            click.echo("Top-level user: {}".format(user))
+            repl(ctx)
+
+    @cli.command()
+    @click.option("--user")
+    def c1(user):
+        click.echo("Executed C1 with {}!".format(user))
+
+    c = ClickCompleter(cli)
+
+    completions = list(c.get_completions(Document(" ")))
+    assert set(x.text for x in completions) == set(["--user", "c1"])
+
+    completions = list(c.get_completions(Document("c1 ")))
+    assert set(x.text for x in completions) == set(["--user"])


### PR DESCRIPTION
I've merged the PR #62, though still to test its actual functionality, it should be done in the command line, but I've still included some test cases for checking the auto completion for those subcommands

Solves: #58 