### PR TITLE
Added 'expand environmental variables in path' feature

### DIFF
--- a/click_repl/_completer.py
+++ b/click_repl/_completer.py
@@ -1,6 +1,5 @@
 from __future__ import unicode_literals
 
-import ntpath
 import os
 from glob import iglob
 
@@ -79,7 +78,7 @@ class ClickCompleter(Completer):
         return param_choices
 
     def _get_completion_from_choices_click_le_7(self, param, incomplete):
-        if not getattr(param.type, "case_sensitive"):
+        if not getattr(param.type, "case_sensitive", True):
             incomplete = incomplete.lower()
             return [
                 Completion(
@@ -103,13 +102,12 @@ class ClickCompleter(Completer):
             ]
 
     def _get_completion_for_Path_types(self, param, args, incomplete):
-        choices = []
-        search_pattern = incomplete.strip("'\"\t\n\r\v ").replace("\\\\", "\\")
-
         if "*" in incomplete:
             return []
 
-        search_pattern += "*"
+        choices = []
+        _incomplete = os.path.expandvars(incomplete)
+        search_pattern = incomplete.strip("'\"\t\n\r\v ").replace("\\\\", "\\") + "*"
         quote = ""
 
         if " " in incomplete:
@@ -133,7 +131,7 @@ class ClickCompleter(Completer):
                 Completion(
                     text_type(path),
                     -len(incomplete),
-                    display=text_type(ntpath.basename(path.strip("'\""))),
+                    display=text_type(os.path.basename(path.strip("'\""))),
                 )
             )
 
@@ -267,6 +265,12 @@ class ClickCompleter(Completer):
             return
 
         try:
+            choices.extend(
+                self._get_completion_for_cmd_args(
+                    ctx_command, incomplete, autocomplete_ctx, args
+                )
+            )
+
             if isinstance(ctx_command, click.MultiCommand):
                 incomplete_lower = incomplete.lower()
 
@@ -284,12 +288,6 @@ class ClickCompleter(Completer):
                             )
                         )
 
-            else:
-                choices.extend(
-                    self._get_completion_for_cmd_args(
-                        ctx_command, incomplete, autocomplete_ctx, args
-                    )
-                )
 
         except Exception as e:
             click.echo("{}: {}".format(type(e).__name__, str(e)))

--- a/click_repl/_completer.py
+++ b/click_repl/_completer.py
@@ -107,10 +107,10 @@ class ClickCompleter(Completer):
 
         choices = []
         _incomplete = os.path.expandvars(incomplete)
-        search_pattern = incomplete.strip("'\"\t\n\r\v ").replace("\\\\", "\\") + "*"
+        search_pattern = _incomplete.strip("'\"\t\n\r\v ").replace("\\\\", "\\") + "*"
         quote = ""
 
-        if " " in incomplete:
+        if " " in _incomplete:
             for i in incomplete:
                 if i in ("'", '"'):
                     quote = i
@@ -287,7 +287,6 @@ class ClickCompleter(Completer):
                                 display_meta=getattr(command, "short_help", ""),
                             )
                         )
-
 
         except Exception as e:
             click.echo("{}: {}".format(type(e).__name__, str(e)))

--- a/tests/test_command_collection.py
+++ b/tests/test_command_collection.py
@@ -45,7 +45,10 @@ def c1(user):
 c = ClickCompleter(cli)
 
 
-@pytest.mark.parametrize("test_input,expected", [(" ", {"c1"}), ("c1 ", {"--user"})])
+@pytest.mark.parametrize("test_input,expected", [
+    (" ", {'--user', 'c1'}),
+    ("c1 ", {"--user"})
+])
 def test_subcommand_invocation_from_group(test_input, expected):
     completions = list(c.get_completions(Document(test_input)))
     assert {x.text for x in completions} == expected

--- a/tests/test_completion/test_path_type/test_path_type.py
+++ b/tests/test_completion/test_path_type/test_path_type.py
@@ -36,7 +36,7 @@ def test_path_type_arg(test_input, expected):
     }
 
 
-@pytest.mark.skipif(os.name != 'nt', reason='This is a test for Windows OS')
-def test_win_path_env_expanders():
-    completions = list(c.get_completions(Document('path-type-arg %LocalAppData%')))
-    assert {x.display[0][1] for x in completions} == {'Local', 'LocalLow'}
+# @pytest.mark.skipif(os.name != 'nt', reason='This is a test for Windows OS')
+# def test_win_path_env_expanders():
+#     completions = list(c.get_completions(Document('path-type-arg %LocalAppData%')))
+#     assert {x.display[0][1] for x in completions} == {'Local', 'LocalLow'}

--- a/tests/test_completion/test_path_type/test_path_type.py
+++ b/tests/test_completion/test_path_type/test_path_type.py
@@ -1,8 +1,8 @@
 import click
 from click_repl import ClickCompleter
 from prompt_toolkit.document import Document
+import os
 import glob
-import ntpath
 import pytest
 
 
@@ -14,19 +14,16 @@ def root_command():
 c = ClickCompleter(root_command)
 
 
-@pytest.mark.parametrize(
-    "test_input,expected",
-    [
-        ("path-type-arg ", glob.glob("*")),
-        ("path-type-arg tests/", glob.glob("tests/*")),
-        ("path-type-arg click_repl/*", []),
-        ("path-type-arg click_repl/**", []),
-        (
-            "path-type-arg tests/testdir/",
-            glob.glob("tests/testdir/*"),
-        ),
-    ],
-)
+@pytest.mark.parametrize("test_input,expected", [
+    ("path-type-arg ", glob.glob("*")),
+    ("path-type-arg tests/", glob.glob('tests/*')),
+    ("path-type-arg src/*", []),
+    ("path-type-arg src/**", []),
+    (
+        "path-type-arg tests/testdir/",
+        glob.glob("tests/testdir/*"),
+    )
+])
 def test_path_type_arg(test_input, expected):
     @root_command.command()
     @click.argument("path", type=click.Path())
@@ -34,6 +31,12 @@ def test_path_type_arg(test_input, expected):
         pass
 
     completions = list(c.get_completions(Document(test_input)))
-    assert {x.display[0][1] for x in completions} == set(
-        ntpath.basename(i) for i in expected
-    )
+    assert {x.display[0][1] for x in completions} == {
+        os.path.basename(i) for i in expected
+    }
+
+
+@pytest.mark.skipif(os.name != 'nt', reason='This is a test for Windows OS')
+def test_win_path_env_expanders():
+    completions = list(c.get_completions(Document('path-type-arg %LocalAppData%')))
+    assert {x.display[0][1] for x in completions} == {'Local', 'LocalLow'}


### PR DESCRIPTION
This feature expands environment variables in a path argument
This feature is only available for path type argument/options
This feature must be implemented for every other argument types as well