### PR TITLE
Fix for issue #92

### DIFF
--- a/click_repl/_repl.py
+++ b/click_repl/_repl.py
@@ -109,15 +109,13 @@ def repl(
             break
 
         try:
-            # default_map passes the top-level params to the new group to
-            # support top-level required params that would reject the
-            # invocation if missing.
-            with group.make_context(
-                None, args, parent=group_ctx, default_map=old_ctx.params
-            ) as ctx:
-                group.invoke(ctx)
-                ctx.exit()
-
+            # The group command will dispatch based on args.
+            old_protected_args = group_ctx.protected_args
+            try:
+                group_ctx.protected_args = args
+                group.invoke(group_ctx)
+            finally:
+                group_ctx.protected_args = old_protected_args
         except click.ClickException as e:
             e.show()
         except (ClickExit, SystemExit):

--- a/tests/test_repl.py
+++ b/tests/test_repl.py
@@ -1,6 +1,21 @@
+import contextlib
+import sys
+
 import click
 import click_repl
 import pytest
+
+from io import StringIO
+
+
+@contextlib.contextmanager
+def mock_stdin(text):
+    old_stdin = sys.stdin
+    try:
+        sys.stdin = StringIO(text)
+        yield sys.stdin
+    finally:
+        sys.stdin = old_stdin
 
 
 def test_simple_repl():
@@ -21,7 +36,65 @@ def test_simple_repl():
     click_repl.register_repl(cli)
 
     with pytest.raises(SystemExit):
-        cli()
+        cli(args=[], prog_name="test_simple_repl")
+
+
+def test_repl_dispatches_subcommand(capsys):
+    @click.group(invoke_without_command=True)
+    @click.pass_context
+    def cli(ctx):
+        if ctx.invoked_subcommand is None:
+            click_repl.repl(ctx)
+
+    @cli.command()
+    def foo():
+        print("Foo!")
+
+    with mock_stdin("foo\n"):
+        with pytest.raises(SystemExit):
+            cli(args=[], prog_name="test_repl_dispatch_subcommand")
+    assert capsys.readouterr().out == "Foo!\n"
+
+
+def test_group_command_called_once(capsys):
+    @click.group(invoke_without_command=True)
+    @click.pass_context
+    def cli(ctx):
+        print("cli()")
+        if ctx.invoked_subcommand is None:
+            click_repl.repl(ctx)
+
+    @cli.command()
+    def foo():
+        print("Foo!")
+
+    @cli.command()
+    def bar():
+        print("Bar!")
+
+    with mock_stdin("foo\nbar\n"):
+        with pytest.raises(SystemExit):
+            cli(args=[], prog_name="test_group_called_once")
+    assert capsys.readouterr().out == "cli()\nFoo!\nBar!\n"
+
+
+def test_independant_args(capsys):
+    @click.group(invoke_without_command=True)
+    @click.argument("argument")
+    @click.pass_context
+    def cli(ctx, argument):
+        print("cli(%s)" % argument)
+        if ctx.invoked_subcommand is None:
+            click_repl.repl(ctx)
+
+    @cli.command()
+    def foo():
+        print("Foo!")
+
+    with mock_stdin("foo\n"):
+        with pytest.raises(SystemExit):
+            cli(args=["command-line-argument"], prog_name="test_group_called_once")
+    assert capsys.readouterr().out == "cli(command-line-argument)\nFoo!\n"
 
 
 def test_exit_repl_function():
@@ -41,7 +114,7 @@ def test_inputs(capfd):
         click_repl.repl(click.get_current_context())
 
     try:
-        cli()
+        cli(args=[], prog_name="test_inputs")
     except (SystemExit, Exception) as e:
         if (
             type(e).__name__ == "prompt_toolkit.output.win32.NoConsoleScreenBufferError"


### PR DESCRIPTION
I've added three tests:

- One demonstrates that subcommands work with repl() - there was no such test.
- The other two demonstrates the issue documented in #92. 

Not sure yet on how to make them pass, welcoming any ideas.