### PR TITLE
Hide already used (non-`multiple`) options

### DIFF
--- a/click_repl/_completer.py
+++ b/click_repl/_completer.py
@@ -199,15 +199,23 @@ class ClickCompleter(Completer):
                 continue
 
             elif isinstance(param, click.Option):
-                for option in param.opts + param.secondary_opts:
+                opts = param.opts + param.secondary_opts
+                previous_args = args[: param.nargs * -1]
+                current_args = args[param.nargs * -1 :]
+
+                already_present = any([
+                    opt in previous_args for opt in opts
+                ])
+
+                for option in opts:
                     # We want to make sure if this parameter was called
                     # If we are inside a parameter that was called, we want to show only
                     # relevant choices
-                    if option in args[param.nargs * -1 :]:  # noqa: E203
+                    if option in current_args:  # noqa: E203
                         param_called = True
                         break
 
-                    elif option.startswith(incomplete):
+                    elif option.startswith(incomplete) and not (already_present and not param.multiple):
                         choices.append(
                             Completion(
                                 text_type(option),

--- a/click_repl/_completer.py
+++ b/click_repl/_completer.py
@@ -33,12 +33,13 @@ def text_type(text):
 class ClickCompleter(Completer):
     __slots__ = ("cli", "ctx", "parsed_args", "parsed_ctx", "ctx_command")
 
-    def __init__(self, cli, ctx):
+    def __init__(self, cli, ctx, show_only_unused=False):
         self.cli = cli
         self.ctx = ctx
         self.parsed_args = []
         self.parsed_ctx = ctx
         self.ctx_command = ctx.command
+        self.show_only_unused = show_only_unused
 
     def _get_completion_from_autocompletion_functions(
         self,
@@ -206,6 +207,7 @@ class ClickCompleter(Completer):
                 already_present = any([
                     opt in previous_args for opt in opts
                 ])
+                hide = self.show_only_unused and already_present and not param.multiple
 
                 for option in opts:
                     # We want to make sure if this parameter was called
@@ -215,7 +217,7 @@ class ClickCompleter(Completer):
                         param_called = True
                         break
 
-                    elif option.startswith(incomplete) and not (already_present and not param.multiple):
+                    elif option.startswith(incomplete) and not hide:
                         choices.append(
                             Completion(
                                 text_type(option),

--- a/tests/test_completion/test_common_tests/test_option_completion.py
+++ b/tests/test_completion/test_common_tests/test_option_completion.py
@@ -32,3 +32,29 @@ def test_boolean_option():
 
     completions = list(c.get_completions(Document("bool-option --foo t")))
     assert {x.text for x in completions} == {"true"}
+
+
+def test_unique_option():
+    @root_command.command()
+    @click.option("-u", type=click.BOOL)
+    def bool_option(foo):
+        pass
+
+    completions = list(c.get_completions(Document("bool-option ")))
+    assert {x.text for x in completions} == {"-u"}
+
+    completions = list(c.get_completions(Document("bool-option -u t ")))
+    assert len(completions) == 0
+
+
+def test_multiple_option():
+    @root_command.command()
+    @click.option("-u", type=click.BOOL, multiple=True)
+    def bool_option(foo):
+        pass
+
+    completions = list(c.get_completions(Document("bool-option ")))
+    assert {x.text for x in completions} == {"-u"}
+
+    completions = list(c.get_completions(Document("bool-option -u t ")))
+    assert {x.text for x in completions} == {"-u"}

--- a/tests/test_completion/test_common_tests/test_option_completion.py
+++ b/tests/test_completion/test_common_tests/test_option_completion.py
@@ -34,27 +34,41 @@ def test_boolean_option():
     assert {x.text for x in completions} == {"true"}
 
 
-def test_unique_option():
+def test_only_unused_with_unique_option():
     @root_command.command()
     @click.option("-u", type=click.BOOL)
-    def bool_option(foo):
+    def unique_option(u):
         pass
 
-    completions = list(c.get_completions(Document("bool-option ")))
+    c.show_only_unused = True
+
+    completions = list(c.get_completions(Document("unique-option ")))
     assert {x.text for x in completions} == {"-u"}
 
-    completions = list(c.get_completions(Document("bool-option -u t ")))
+    completions = list(c.get_completions(Document("unique-option -u t ")))
     assert len(completions) == 0
 
+    c.show_only_unused = False
 
-def test_multiple_option():
-    @root_command.command()
-    @click.option("-u", type=click.BOOL, multiple=True)
-    def bool_option(foo):
-        pass
-
-    completions = list(c.get_completions(Document("bool-option ")))
+    completions = list(c.get_completions(Document("unique-option -u t ")))
     assert {x.text for x in completions} == {"-u"}
 
-    completions = list(c.get_completions(Document("bool-option -u t ")))
+
+def test_only_unused_with_multiple_option():
+    @root_command.command()
+    @click.option("-u", type=click.BOOL, multiple=True)
+    def multiple_option(u):
+        pass
+
+    c.show_only_unused = True
+
+    completions = list(c.get_completions(Document("multiple-option ")))
+    assert {x.text for x in completions} == {"-u"}
+
+    completions = list(c.get_completions(Document("multiple-option -u t ")))
+    assert {x.text for x in completions} == {"-u"}
+
+    c.show_only_unused = False
+
+    completions = list(c.get_completions(Document("multiple-option -u t ")))
     assert {x.text for x in completions} == {"-u"}


### PR DESCRIPTION
Change only applied for options with `multiple=False`.

### Before
```sh
> cmd <TAB>
                      --foo
                      --bar
> cmd --foo t <TAB>
                      --foo
                      --bar
```

### After
```sh
> cmd <TAB>
                      --foo
                      --bar
> cmd --foo t <TAB>
                      --bar
```