### PR TITLE
Add a `shortest_only` option

### DIFF
--- a/click_repl/_completer.py
+++ b/click_repl/_completer.py
@@ -213,9 +213,9 @@ class ClickCompleter(Completer):
 
                 # Show only shortest opt
                 if (self.shortest_only
-                        and not incomplete        # just typed a space
-                        and args[-1] not in opts  # not selecting a value for a longer version of this option
-                ):
+                        and not incomplete  # just typed a space
+                        # not selecting a value for a longer version of this option
+                        and args[-1] not in opts):
                     opts = [min(opts, key=len)]
 
                 for option in opts:

--- a/click_repl/_completer.py
+++ b/click_repl/_completer.py
@@ -33,13 +33,14 @@ def text_type(text):
 class ClickCompleter(Completer):
     __slots__ = ("cli", "ctx", "parsed_args", "parsed_ctx", "ctx_command")
 
-    def __init__(self, cli, ctx, show_only_unused=False):
+    def __init__(self, cli, ctx, show_only_unused=False, shortest_only=False):
         self.cli = cli
         self.ctx = ctx
         self.parsed_args = []
         self.parsed_ctx = ctx
         self.ctx_command = ctx.command
         self.show_only_unused = show_only_unused
+        self.shortest_only = shortest_only
 
     def _get_completion_from_autocompletion_functions(
         self,
@@ -204,10 +205,18 @@ class ClickCompleter(Completer):
                 previous_args = args[: param.nargs * -1]
                 current_args = args[param.nargs * -1 :]
 
+                # Show only unused opts
                 already_present = any([
                     opt in previous_args for opt in opts
                 ])
                 hide = self.show_only_unused and already_present and not param.multiple
+
+                # Show only shortest opt
+                if (self.shortest_only
+                        and not incomplete        # just typed a space
+                        and args[-1] not in opts  # not selecting a value for a longer version of this option
+                ):
+                    opts = [min(opts, key=len)]
 
                 for option in opts:
                     # We want to make sure if this parameter was called

--- a/tests/test_completion/test_common_tests/test_option_completion.py
+++ b/tests/test_completion/test_common_tests/test_option_completion.py
@@ -76,3 +76,28 @@ def test_only_unused_with_multiple_option():
 
     completions = list(c.get_completions(Document("multiple-option -u t ")))
     assert {x.text for x in completions} == {"-u"}
+
+
+def test_shortest_only_mode():
+    @root_command.command()
+    @click.option("--foo", "-f", is_flag=True)
+    @click.option("-b", "--bar", is_flag=True)
+    @click.option("--foobar", is_flag=True)
+    def shortest_only(foo, bar, foobar):
+        pass
+
+    c.shortest_only = True
+
+    completions = list(c.get_completions(Document("shortest-only ")))
+    assert {x.text for x in completions} == {"-f", "-b", "--foobar"}
+
+    completions = list(c.get_completions(Document("shortest-only -")))
+    assert {x.text for x in completions} == {"-f", "--foo", "-b", "--bar", "--foobar"}
+
+    completions = list(c.get_completions(Document("shortest-only --f")))
+    assert {x.text for x in completions} == {"--foo", "--foobar"}
+
+    c.shortest_only = False
+
+    completions = list(c.get_completions(Document("shortest-only ")))
+    assert {x.text for x in completions} == {"-f", "--foo", "-b", "--bar", "--foobar"}


### PR DESCRIPTION
The `ClickCompleter` can now receive a `shortest_only` keyword argument.

If set to `True`, only the shortest version of each option will be shown by default (ie. if we keep pressing `Tab` & `Space`).

### Before
```sh
> cmd <TAB>
            --verbose
            -v
> cmd -<TAB>
            --verbose
            -v
```

### After
```sh
> cmd <TAB>
            -v
> cmd -<TAB>
            --verbose
            -v
```