### PR TITLE
Fix values shown for wrong option

### DIFF
--- a/click_repl/_completer.py
+++ b/click_repl/_completer.py
@@ -220,6 +220,7 @@ class ClickCompleter(Completer):
                     choices = self._get_completion_from_params(
                         autocomplete_ctx, args, param, incomplete
                     )
+                    break
 
             elif isinstance(param, click.Argument):
                 choices.extend(

--- a/tests/test_completion/test_common_tests/test_option_completion.py
+++ b/tests/test_completion/test_common_tests/test_option_completion.py
@@ -14,11 +14,15 @@ c = ClickCompleter(root_command, click.Context(root_command))
 def test_option_choices():
     @root_command.command()
     @click.option("--handler", type=click.Choice(("foo", "bar")))
+    @click.option("--wrong", type=click.Choice(("bogged", "bogus")))
     def option_choices(handler):
         pass
 
     completions = list(c.get_completions(Document("option-choices --handler ")))
     assert {x.text for x in completions} == {"foo", "bar"}
+
+    completions = list(c.get_completions(Document("option-choices --wrong ")))
+    assert {x.text for x in completions} == {"bogged", "bogus"}
 
 
 def test_boolean_option():


### PR DESCRIPTION
When completing option values, only values corresponding to the option being completed should be shown.

Following exemples are based on a command looking like this:
```py
@click.command()
@click.option('-a', type=click.Choice(['a_val1', 'a_val2']))
@click.option('-b', type=click.Choice(['b_val1', 'b_val2']))
def cli():
    pass
```

### Before
```sh
> cmd -a <TAB>
               a_val1
               a_val2
               b_val1
               b_val2
```

### After
```sh
> cmd -a <TAB>
               a_val1
               a_val2
```