### PR TITLE
Fixed autocomplete execution bug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,11 @@
 release:
-	@python setup.py sdist bdist_wheel upload
+	@python3 setup.py sdist bdist_wheel upload
 .PHONY: release
 
+build-dev:
+	@python3 setup.py sdist bdist_wheel
+.PHONY: build-dev
+
 testrepl:
-	@python bin/testrepl.py repl
+	@python3 bin/testrepl.py repl
 .PHONY: testrepl

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,7 @@
 release:
-	@python3 setup.py sdist bdist_wheel upload
+	@python setup.py sdist bdist_wheel upload
 .PHONY: release
 
-build-dev:
-	@python3 setup.py sdist bdist_wheel
-.PHONY: build-dev
-
 testrepl:
-	@python3 bin/testrepl.py repl
+	@python bin/testrepl.py repl
 .PHONY: testrepl

--- a/click_repl/_completer.py
+++ b/click_repl/_completer.py
@@ -241,6 +241,8 @@ class ClickCompleter(Completer):
                     )
                     break
 
+                param_called = False
+
             elif isinstance(param, click.Argument):
                 choices.extend(
                     self._get_completion_from_params(


### PR DESCRIPTION
Without setting param_called back to False, all options with shell_complete are automatically executed. All options are executed from iterating over a list of current arg to end of arg list. This results in only the last option's values being displayed.