### PR TITLE
Added typehints and mypy test env in tox

### DIFF
--- a/click_repl/globals_.py
+++ b/click_repl/globals_.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import sys
-from typing import TYPE_CHECKING, NoReturn
+from typing import TYPE_CHECKING, NoReturn, overload
 
 from ._ctx_stack import _context_stack
 
@@ -10,6 +10,16 @@ if TYPE_CHECKING:
 
 
 ISATTY = sys.stdin.isatty()
+
+
+@overload
+def get_current_repl_ctx() -> ReplContext | NoReturn:
+    ...
+
+
+@overload
+def get_current_repl_ctx(silent: bool = False) -> ReplContext | NoReturn | None:
+    ...
 
 
 def get_current_repl_ctx(silent: bool = False) -> ReplContext | NoReturn | None:

--- a/click_repl/utils.py
+++ b/click_repl/utils.py
@@ -1,10 +1,18 @@
-import click
+from __future__ import annotations
+
 import os
 import shlex
-import sys
+import typing as t
 from collections import defaultdict
+from typing import Callable, Generator, Iterator, NoReturn, Sequence
+
+import click
+from typing_extensions import TypeAlias
 
 from .exceptions import CommandLineParserError, ExitReplException
+
+T = t.TypeVar("T")
+InternalCommandCallback: TypeAlias = Callable[[], None]
 
 
 __all__ = [
@@ -21,15 +29,7 @@ __all__ = [
 ]
 
 
-# Abstract datatypes in collections module are moved to collections.abc
-# module in Python 3.3
-if sys.version_info >= (3, 3):
-    from collections.abc import Iterable, Mapping  # noqa: F811
-else:
-    from collections import Iterable, Mapping
-
-
-def _resolve_context(args, ctx=None):
+def _resolve_context(args: list[str], ctx: click.Context) -> click.Context:
     """Produce the context hierarchy starting with the command and
     traversing the complete arguments. This only follows the commands,
     it doesn't trigger input prompts or callbacks.
@@ -75,10 +75,10 @@ def _resolve_context(args, ctx=None):
     return ctx
 
 
-_internal_commands = {}
+_internal_commands: dict[str, tuple[InternalCommandCallback, str | None]] = {}
 
 
-def split_arg_string(string, posix=True):
+def split_arg_string(string: str, posix: bool = True) -> list[str]:
     """Split an argument string as with :func:`shlex.split`, but don't
     fail if the string is incomplete. Ignores a missing closing quote or
     incomplete escape sequence and uses the partial token as-is.
@@ -107,16 +107,20 @@ def split_arg_string(string, posix=True):
     return out
 
 
-def _register_internal_command(names, target, description=None):
+def _register_internal_command(
+    names: str | Sequence[str] | Generator[str, None, None] | Iterator[str],
+    target: InternalCommandCallback,
+    description: str | None = None,
+) -> None:
     if not hasattr(target, "__call__"):
         raise ValueError("Internal command must be a callable")
 
     if isinstance(names, str):
         names = [names]
 
-    elif isinstance(names, Mapping) or not isinstance(names, Iterable):
+    elif not isinstance(names, (Sequence, Generator, Iterator)):
         raise ValueError(
-            '"names" must be a string, or an iterable object, but got "{}"'.format(
+            '"names" must be a string, or a Sequence of strings, but got "{}"'.format(
                 type(names).__name__
             )
         )
@@ -125,18 +129,20 @@ def _register_internal_command(names, target, description=None):
         _internal_commands[name] = (target, description)
 
 
-def _get_registered_target(name, default=None):
-    target_info = _internal_commands.get(name)
+def _get_registered_target(
+    name: str, default: T | None = None
+) -> InternalCommandCallback | T | None:
+    target_info = _internal_commands.get(name, None)
     if target_info:
         return target_info[0]
     return default
 
 
-def _exit_internal():
+def _exit_internal() -> NoReturn:
     raise ExitReplException()
 
 
-def _help_internal():
+def _help_internal() -> None:
     formatter = click.HelpFormatter()
     formatter.write_heading("REPL help")
     formatter.indent()
@@ -169,10 +175,10 @@ _register_internal_command(
 
 
 def _execute_internal_and_sys_cmds(
-    command,
-    allow_internal_commands=True,
-    allow_system_commands=True,
-):
+    command: str,
+    allow_internal_commands: bool = True,
+    allow_system_commands: bool = True,
+) -> list[str] | None:
     """
     Executes internal, system, and all the other registered click commands from the input
     """
@@ -189,12 +195,12 @@ def _execute_internal_and_sys_cmds(
         raise CommandLineParserError("{}".format(e))
 
 
-def exit():
+def exit() -> NoReturn:
     """Exit the repl"""
     _exit_internal()
 
 
-def dispatch_repl_commands(command):
+def dispatch_repl_commands(command: str) -> bool:
     """
     Execute system commands entered in the repl.
 
@@ -207,7 +213,7 @@ def dispatch_repl_commands(command):
     return False
 
 
-def handle_internal_commands(command):
+def handle_internal_commands(command: str) -> None:
     """
     Run repl-internal commands.
 

--- a/click_repl/utils.py
+++ b/click_repl/utils.py
@@ -159,8 +159,7 @@ def _help_internal():
             for description, mnemonics in info_table.items()
         )
 
-    val = formatter.getvalue()  # type: str
-    return val
+    print(formatter.getvalue())
 
 
 _register_internal_command(["q", "quit", "exit"], _exit_internal, "exits the repl")
@@ -180,11 +179,9 @@ def _execute_internal_and_sys_cmds(
     if allow_system_commands and dispatch_repl_commands(command):
         return None
 
-    if allow_internal_commands:
-        result = handle_internal_commands(command)
-        if isinstance(result, str):
-            click.echo(result)
-            return None
+    if allow_internal_commands and command.startswith(":"):
+        handle_internal_commands(command)
+        return None
 
     try:
         return split_arg_string(command)
@@ -216,7 +213,6 @@ def handle_internal_commands(command):
 
     Repl-internal commands are all commands starting with ":".
     """
-    if command.startswith(":"):
-        target = _get_registered_target(command[1:], default=None)
-        if target:
-            return target()
+    target = _get_registered_target(command[1:], default=None)
+    if target:
+        target()

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,6 +39,8 @@ testing =
   pytest>=7.2.1
   pytest-cov>=4.0.0
   tox>=4.4.3
+  flake8>=6.0.0
+  mypy>=1.9.0
 
 [flake8]
 ignore = E203, E266, W503, E402, E731, C901

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ isolated_build = true
 [gh-actions]
 python =
     3.7: py37, click7, flake8
-    3.8: py38
+    3.8: py38, mypy
     3.9: py39
     3.10: py310
     3.11: py311
@@ -32,6 +32,11 @@ commands =
 basepython = python3.7
 deps = flake8
 commands = flake8 click_repl tests
+
+[testenv:mypy]
+basepython = python3.8
+deps = mypy
+commands = mypy click_repl
 
 [testenv:click7]
 basepython = python3.10


### PR DESCRIPTION
This PR adds typehints to the existing code, and added mypy test env in tox to perform type checking in GHA

Also, changed `click_repl.utils._help_internal` function to just print the help text, rather than returning it, so that all function callbacks for internal command can be in the same type of `Callable[[], None]`