### PR TITLE
Support Python 3.13; Limit Click version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,3 +5,17 @@ release:
 testrepl:
 	@python bin/testrepl.py repl
 .PHONY: testrepl
+
+venv:
+	@python -m venv .venv
+	.venv/bin/pip install --upgrade pip
+	.venv/bin/pip install tox
+.PHONY: venv
+
+tox: venv
+	.venv/bin/tox
+.PHONY: tox
+
+clean:
+	rm -rf .venv .tox
+.PHONY: clean

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 name = click-repl
 version = attr: click_repl.__version__
 description = REPL plugin for Click
-description-file = README.md
+description_file = README.md
 long_description_content_type = text/markdown
 long_description = file: README.md
 
@@ -27,7 +27,7 @@ packages=
   click_repl
 
 install_requires =
-  click>=7.0
+  click>=7.0,<8.2.0
   prompt_toolkit>=3.0.36
   typing-extensions>=4.7.0
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{py,38,39,310,311,312}
+    py{py,38,39,310,311,312,313}
     flake8
     click7
 
@@ -14,6 +14,7 @@ python =
     3.10: py310
     3.11: py311
     3.12: py312
+    3.13: py313
 
 [testenv]
 setenv =


### PR DESCRIPTION
Until support for Click 8.2.0 and higher is added, it should be explicitly specified, that this Click isn't supported.